### PR TITLE
gnu compiler workaround

### DIFF
--- a/ali.c
+++ b/ali.c
@@ -30,7 +30,7 @@ int ali_(	float	*H,
  VIBLEVEL	*v_level;
 
  BAND_CVT	*cvt_band;
- PBAND		pcvt_band;
+ PBAND_CVT	pcvt_band;
 
  BAND_CVV	*cvv_band;
 


### PR DESCRIPTION
	modified:   ali.c

Explanation from claude:

  In ali.c line 33, pcvt_band is declared as type PBAND:
  PBAND  pcvt_band;

  But the two functions it's passed to both expect PBAND_CVT *:
  - compute_static_coll_coeff(...) — argument 3 expects PBAND_CVT * (subroutines.h:142)
  - compute_populations(...) — argument 2 expects PBAND_CVT * (subroutines.h:173)

  So &pcvt_band is PBAND * but PBAND_CVT * is required.

  Interestingly, PBAND and PBAND_CVT are structurally identical (both have NUM, type,
  *band, **rate_Up, **rate_Do) — the compiler treats them as distinct types, but all
  fields used in ali.c (pcvt_band.type, pcvt_band.NUM,
   pcvt_band.rate_Up, pcvt_band.rate_Do) exist in both.